### PR TITLE
For reasons unknown,  pz-workflow was deleting its indexes on start.

### DIFF
--- a/server/resource_db.go
+++ b/server/resource_db.go
@@ -27,7 +27,7 @@ func NewResourceDB(server *Server, esi elasticsearch.IIndex) (*ResourceDB, error
 		Esi:    esi,
 	}
 
-	_ = esi.Delete()
+	// _ = esi.Delete()
 
 	err := esi.Create()
 	if err != nil {


### PR DESCRIPTION
Commented out until we figure out why it was doing it.
