### PR TITLE
8003 cron tests

### DIFF
--- a/systest/sys_test.go
+++ b/systest/sys_test.go
@@ -606,7 +606,7 @@ func (suite *WorkflowTester) Test13RepeatingEvent() {
 			"beta":  goodBeta,
 			"alpha": goodAlpha,
 		},
-		CronSchedule: "* * * * * *",
+		CronSchedule: "*/2 * * * * *",
 	}
 
 	ack, err := client.PostEvent(repeatingEvent)
@@ -615,7 +615,7 @@ func (suite *WorkflowTester) Test13RepeatingEvent() {
 	suite.repeatID = ack.EventID
 	log.Printf("RepeatId: %s", suite.repeatID)
 
-	time.Sleep(10 * time.Second)
+	time.Sleep(20 * time.Second)
 
 	err = client.DeleteEvent(suite.repeatID)
 	assert.NoError(err)
@@ -624,7 +624,8 @@ func (suite *WorkflowTester) Test13RepeatingEvent() {
 	numEventsAfter := len(*allEvents)
 
 	numEventsCreated := numEventsAfter - numEventsBefore
-	assert.InDelta(7, numEventsCreated, 3.0)
+	log.Printf("Number of repeating events created: %d", numEventsCreated)
+	assert.InDelta(10, numEventsCreated, 4.0)
 }
 
 //---------------------------------------------------------------------

--- a/systest/sys_test.go
+++ b/systest/sys_test.go
@@ -598,7 +598,7 @@ func (suite *WorkflowTester) Test13RepeatingEvent() {
 	client := suite.client
 
 	allEvents, err := client.GetAllEventsByEventType(suite.eventTypeID)
-	numEventsBefore := len(allEvents)
+	numEventsBefore := len(*allEvents)
 
 	repeatingEvent := &workflow.Event{
 		EventTypeID: suite.eventTypeID,
@@ -621,7 +621,7 @@ func (suite *WorkflowTester) Test13RepeatingEvent() {
 	assert.NoError(err)
 
 	allEvents, err = client.GetAllEventsByEventType(suite.eventTypeID)
-	numEventsAfter := len(allEvents)
+	numEventsAfter := len(*allEvents)
 
 	numEventsCreated := numEventsAfter - numEventsBefore
 	assert.InDelta(7, numEventsCreated, 3.0)


### PR DESCRIPTION
The test for repeating events does the following:
1) Get the number of current events for the given eventType
2) Create the repeating event
3) Wait 10 seconds
4) Delete the event
5) Verify the number of new events is 7 (+/- 3)
